### PR TITLE
feat!: add tile buttons

### DIFF
--- a/collectivo/collectivo/components/collectivo/Card.vue
+++ b/collectivo/collectivo/components/collectivo/Card.vue
@@ -1,57 +1,33 @@
 <script setup lang="ts">
-defineProps(["variant", "title"]);
+const _ = defineProps({
+  title: {
+    type: String,
+  },
+  color: {
+    type: String,
+  },
+});
 </script>
 
 <template>
-  <div :class="`card ${variant ?? ''}`">
-    <div class="card-corner"></div>
-    <p class="card__title">
+  <div :class="`card bg-${color ?? 'primary'}-50`">
+    <div :class="`card-corner bg-${color ?? 'primary'}-100`"></div>
+    <p v-if="title" class="card__title">
       {{ title }}
     </p>
     <slot name="content"></slot>
   </div>
-
-  <!-- TODO: Button logic -->
-  <!-- <UButton
-        class="mt-6 w-full"
-        variant="solid"
-        color="green"
-        size="base"
-      >
-        Hello again!
-      </UButton> -->
 </template>
 
 <style lang="scss" scoped>
 .card {
-  @apply h-fit w-full bg-green-100 rounded-[15px] relative overflow-hidden p-6;
+  @apply h-fit w-full rounded-[15px] relative overflow-hidden p-6;
   &__title {
     @apply mb-1 font-semibold text-lg leading-[22px];
   }
 
   .card-corner {
-    @apply h-[70px] w-[70px] bg-[#77B3AD]/30 absolute rounded-full right-0 top-0 transform translate-x-2/4 -translate-y-2/4 mt-2 mr-2;
-  }
-
-  &.purple {
-    @apply bg-purple-500;
-    .card-corner {
-      @apply bg-[#F4DBF8];
-    }
-  }
-
-  &.orange {
-    @apply bg-orange-500;
-    .card-corner {
-      @apply bg-[#D36D29]/[15%];
-    }
-  }
-
-  &.gray {
-    @apply bg-purple-500;
-    .card-corner {
-      @apply bg-[#4E3095]/10;
-    }
+    @apply h-[70px] w-[70px] absolute rounded-full right-0 top-0 transform translate-x-2/4 -translate-y-2/4 mt-2 mr-2;
   }
 }
 </style>

--- a/collectivo/collectivo/composables/tiles.ts
+++ b/collectivo/collectivo/composables/tiles.ts
@@ -22,7 +22,9 @@ class CollectivoTileStore {
     const directus = useDirectus();
 
     try {
-      this.data = await directus.request(readItems("collectivo_tiles"));
+      this.data = await directus.request(
+        readItems("collectivo_tiles", { fields: ["*.*"] }),
+      );
     } catch (error) {
       this.error = error;
     }

--- a/collectivo/collectivo/index.d.ts
+++ b/collectivo/collectivo/index.d.ts
@@ -31,10 +31,21 @@ declare global {
     collectivo_members: CollectivoMember[] | number[];
   }
 
+  interface CollectivoTileButton {
+    id: number;
+    collectivo_label: string;
+    collectivo_path: string;
+    collectivo_is_external: boolean;
+  }
+
   interface CollectivoTile {
     id: number;
     name: string;
     content: string;
+    status: "published" | "draft" | "archived";
+    sort: number;
+    collectivo_buttons: CollectivoTileButton[];
+    collectivo_color: string;
   }
 
   interface CollectivoExtension {

--- a/collectivo/collectivo/nuxt.config.ts
+++ b/collectivo/collectivo/nuxt.config.ts
@@ -43,6 +43,7 @@ export default defineNuxtConfig({
   ui: {
     global: true,
     icons: ["system-uicons", "mi", "heroicons"],
+    safelistColors: ["primary", "green", "orange", "blue", "pink", "red"],
   },
   googleFonts: {
     download: true,

--- a/collectivo/collectivo/pages/index.vue
+++ b/collectivo/collectivo/pages/index.vue
@@ -11,15 +11,43 @@ tiles.value.load();
 </script>
 
 <template>
-  <div class="gap-5 columns-1 md:columns-2 lg:columns-3 xl:columns-4">
+  <div class="gap-5 columns-1 md:columns-2 xl:columns-3 2xl:columns-4">
     <CollectivoCard
       v-for="tile in tiles.data"
       :key="tile.id"
       class="mb-5"
       :title="tile.name"
+      :color="tile.collectivo_color"
     >
       <template #content>
+        <!-- v-html is safe, as it is parsed from markdown -->
+        <!-- eslint-disable-next-line -->
         <div v-html="parse(tile.content)"></div>
+
+        <div v-if="tile.collectivo_buttons" class="flex flex-wrap gap-2 pt-3">
+          <template v-for="button in tile.collectivo_buttons" :key="button.id">
+            <a
+              v-if="button.collectivo_is_external"
+              :href="button.collectivo_path"
+              target="_blank"
+            >
+              <UButton
+                :label="button.collectivo_label"
+                :color="tile.collectivo_color"
+                size="md"
+                icon="i-heroicons-arrow-top-right-on-square-16-solid"
+                trailing
+              />
+            </a>
+            <NuxtLink v-else :to="button.collectivo_path">
+              <UButton
+                :label="button.collectivo_label"
+                :color="tile.collectivo_color"
+                size="md"
+              />
+            </NuxtLink>
+          </template>
+        </div>
       </template>
     </CollectivoCard>
   </div>

--- a/collectivo/collectivo/server/examples/examples.ts
+++ b/collectivo/collectivo/server/examples/examples.ts
@@ -132,7 +132,26 @@ export default async function examples() {
   // Create some tiles
   console.info("Creating tiles");
   await directus.request(deleteItems("collectivo_tiles", { limit: 1000 }));
-  const tileNames = ["Tile 1", "Tile 2", "Tile 3", "Tile 4"];
+
+  const tileData = [
+    {
+      name: "Tile 1",
+      color: "primary",
+    },
+    {
+      name: "Tile 2",
+      color: "green",
+    },
+    {
+      name: "Tile 3",
+      color: "orange",
+    },
+    {
+      name: "Tile 4",
+      color: "blue",
+    },
+  ];
+
   const tiles = [];
 
   const tileButton = {
@@ -142,10 +161,11 @@ export default async function examples() {
     status: "published",
   };
 
-  for (const tileName of tileNames) {
+  for (const td of tileData) {
     tiles.push({
-      name: tileName,
+      name: td.name,
       content: "Hello! I am an example tile!",
+      collectivo_color: td.color,
     });
   }
 

--- a/collectivo/collectivo/server/examples/examples.ts
+++ b/collectivo/collectivo/server/examples/examples.ts
@@ -1,4 +1,5 @@
 import {
+  createItem,
   createItems,
   createUser,
   deleteItems,
@@ -134,6 +135,13 @@ export default async function examples() {
   const tileNames = ["Tile 1", "Tile 2", "Tile 3", "Tile 4"];
   const tiles = [];
 
+  const tileButton = {
+    collectivo_label: "Example Button",
+    collectivo_path: "/some/path",
+    collectivo_tile: "",
+    status: "published",
+  };
+
   for (const tileName of tileNames) {
     tiles.push({
       name: tileName,
@@ -142,7 +150,17 @@ export default async function examples() {
   }
 
   try {
-    await directus.request(createItems("collectivo_tiles", tiles));
+    const tilesRes = await directus.request(
+      createItems("collectivo_tiles", tiles),
+    );
+
+    for (const tile of tilesRes) {
+      tileButton.collectivo_tile = tile.id;
+
+      await directus.request(
+        createItem("collectivo_tiles_buttons", tileButton),
+      );
+    }
   } catch (error) {
     console.info(error);
   }

--- a/collectivo/collectivo/server/schemas/003_tags.ts
+++ b/collectivo/collectivo/server/schemas/003_tags.ts
@@ -7,7 +7,7 @@ const collection = "collectivo_tags";
 schema.collections = [
   {
     collection: collection,
-    schema: directusCollectionSchema(),
+    schema: { name: collection },
     meta: {
       icon: "sell",
       sort: 510,

--- a/collectivo/collectivo/server/schemas/004_tiles.ts
+++ b/collectivo/collectivo/server/schemas/004_tiles.ts
@@ -2,12 +2,10 @@ const schema = initSchema("collectivo", "0.0.1");
 
 export default schema;
 
-const collection = "collectivo_tiles";
-
 schema.collections = [
   {
-    collection: collection,
-    schema: directusCollectionSchema(),
+    collection: "collectivo_tiles",
+    schema: { name: "collectivo_tiles" },
     meta: {
       icon: "dashboard",
       sort: 520,
@@ -31,15 +29,39 @@ schema.collections = [
       ],
     },
   },
+  {
+    collection: "collectivo_tiles_buttons",
+    schema: { name: "collectivo_tiles_buttons" },
+    meta: {
+      hidden: true,
+      display_template: "{{collectivo_label}}",
+      sort_field: "sort",
+      translations: [
+        {
+          language: "en-US",
+          translation: "Tile Buttons",
+          singular: "Tile Button",
+          plural: "Tile Buttons",
+        },
+        {
+          language: "de-DE",
+          translation: "Kachel Buttons",
+          singular: "Kachel Button",
+          plural: "Kachel Buttons",
+        },
+      ],
+    },
+  },
 ];
 
 schema.fields = [
-  directusNameField(collection),
-  directusSortField(collection),
-  directusStatusField(collection),
-  ...directusSystemFields(collection),
+  directusNameField("collectivo_tiles"),
+  directusSortField("collectivo_tiles"),
+  directusSortField("collectivo_tiles_buttons"),
+  directusStatusField("collectivo_tiles"),
+  ...directusSystemFields("collectivo_tiles"),
   {
-    collection: collection,
+    collection: "collectivo_tiles",
     field: "content",
     type: "text",
     schema: {},
@@ -67,12 +89,92 @@ schema.fields = [
       },
     },
   },
+
+  // Button fields
+  {
+    field: "collectivo_label",
+    collection: "collectivo_tiles_buttons",
+    type: "string",
+    meta: {
+      sort: 2,
+      required: true,
+      translations: [
+        { language: "en-US", translation: "Label" },
+        { language: "de-DE", translation: "Label" },
+      ],
+    },
+    schema: {},
+  },
+  {
+    field: "collectivo_path",
+    collection: "collectivo_tiles_buttons",
+    type: "string",
+    meta: {
+      sort: 2,
+      translations: [
+        { language: "en-US", translation: "Path" },
+        { language: "de-DE", translation: "Pfad" },
+      ],
+    },
+    schema: {},
+  },
+  {
+    field: "collectivo_is_external",
+    collection: "collectivo_tiles_buttons",
+    type: "boolean",
+    meta: {
+      sort: 2,
+      required: true,
+      translations: [
+        { language: "en-US", translation: "Path is external" },
+        { language: "de-DE", translation: "Pfad ist extern" },
+      ],
+    },
+    schema: {
+      default_value: true,
+    },
+  },
 ];
+
+schema.createForeignKey("collectivo_tiles_buttons", "collectivo_tiles", {
+  fieldKey: {
+    field: "collectivo_tile",
+    meta: {
+      hidden: true,
+    },
+  },
+  fieldAlias: {
+    field: "collectivo_buttons",
+    meta: {
+      options: {
+        enableSelect: false,
+      },
+      display: "related-values",
+      display_options: {
+        template: "{{collectivo_label}}",
+      },
+      translations: [
+        { language: "en-US", translation: "Buttons" },
+        { language: "de-DE", translation: "Buttons" },
+      ],
+    },
+  },
+  relation: {
+    meta: {
+      sort_field: "sort",
+      one_deselect_action: "delete",
+    },
+    schema: {
+      on_delete: "CASCADE",
+      on_update: "NO ACTION",
+    },
+  },
+});
 
 schema.permissions = [
   {
     roleName: "collectivo_user",
-    collection: collection,
+    collection: "collectivo_tiles",
     action: "read",
     fields: ["*"],
     permissions: {},
@@ -82,7 +184,7 @@ schema.permissions = [
 
 for (const action of ["read", "update", "create", "delete"]) {
   schema.permissions.push({
-    collection: collection,
+    collection: "collectivo_tiles",
     roleName: "collectivo_editor",
     action: action,
     fields: ["*"],

--- a/collectivo/collectivo/server/schemas/004_tiles.ts
+++ b/collectivo/collectivo/server/schemas/004_tiles.ts
@@ -89,6 +89,30 @@ schema.fields = [
       },
     },
   },
+  {
+    field: "collectivo_color",
+    type: "string",
+    schema: { default_value: "primary" },
+    meta: {
+      interface: "select-dropdown",
+      special: null,
+      options: {
+        choices: [
+          { text: "$t:primary", value: "primary" },
+          { text: "$t:green", value: "green" },
+          { text: "$t:orange", value: "orange" },
+          { text: "$t:blue", value: "blue" },
+          { text: "$t:pink", value: "pink" },
+          { text: "$t:red", value: "red" },
+        ],
+      },
+      translations: [
+        { language: "en-US", translation: "Color" },
+        { language: "de-DE", translation: "Farbe" },
+      ],
+    },
+    collection: "collectivo_tiles",
+  },
 
   // Button fields
   {

--- a/collectivo/collectivo/server/schemas/005_messages.ts
+++ b/collectivo/collectivo/server/schemas/005_messages.ts
@@ -163,8 +163,9 @@ schema.fields = [
 ];
 
 for (const coll of ["messages_campaigns", "messages_messages"]) {
-  schema.createO2MRelation(coll, "messages_templates", "messages_template", {
-    field1: {
+  schema.createForeignKey(coll, "messages_templates", {
+    fieldKey: {
+      field: "messages_template",
       meta: {
         required: true,
         display: "related-values",
@@ -175,19 +176,15 @@ for (const coll of ["messages_campaigns", "messages_messages"]) {
   });
 }
 
-schema.createO2MRelation(
-  "messages_messages",
-  "messages_campaigns",
-  "messages_campaign",
-  {
-    field1: {
-      meta: {
-        display: "raw",
-        width: "half",
-      },
+schema.createForeignKey("messages_messages", "messages_campaigns", {
+  fieldKey: {
+    field: "messages_campaign",
+    meta: {
+      display: "raw",
+      width: "half",
     },
   },
-);
+});
 
 schema.createM2MRelation("messages_campaigns", "directus_users", {
   m2mFieldType2: "uuid",

--- a/collectivo/collectivo/server/utils/directusFields.ts
+++ b/collectivo/collectivo/server/utils/directusFields.ts
@@ -1,13 +1,5 @@
 import { DirectusField, NestedPartial } from "@directus/sdk";
 
-export function directusCollectionSchema() {
-  return {
-    schema: "schema",
-    name: "schema",
-    comment: null,
-  };
-}
-
 export function directusNameField(
   collection: string,
   meta?: any,

--- a/collectivo/collectivo/server/utils/schemas.ts
+++ b/collectivo/collectivo/server/utils/schemas.ts
@@ -91,18 +91,17 @@ export class ExtensionSchema {
     );
   };
 
-  createO2MRelation = (
-    CollectionOne: string,
-    CollectionMany: string,
-    ForeignKey: string,
+  createForeignKey = (
+    CollectionKey: string,
+    CollectionAlias: string,
     settings?: directusO2MSettings,
   ) => {
-    createO2MRelation(
-      this,
-      CollectionOne,
-      CollectionMany,
-      ForeignKey,
-      settings,
+    createForeignKey(this, CollectionKey, CollectionAlias, settings);
+  };
+
+  createO2MRelation = () => {
+    throw new Error(
+      "schema.createO2MRelation deprecated. pls use createForeignKey",
     );
   };
 
@@ -232,7 +231,7 @@ function createM2MRelation(
   schema.collections.push({
     collection: m2mCollectionName,
     meta: { hidden: true, icon: "import_export" },
-    schema: directusCollectionSchema(),
+    schema: { name: m2mCollectionName },
   });
 
   schema.fields.push({
@@ -282,40 +281,66 @@ function createM2MRelation(
 }
 
 interface directusO2MSettings {
-  field1?: NestedPartial<DirectusField<any>>;
-  // field2?: NestedPartial<DirectusField<any>> | boolean;
+  fieldKey?: NestedPartial<DirectusField<any>>;
+  fieldAlias?: NestedPartial<DirectusField<any>>;
   relation?: NestedPartial<DirectusRelation<any>>;
 }
 
-export async function createO2MRelation(
+// CollectionOne has the Alias Field - Can have many of CollectionAlias
+// CollectionAlias has the Foreign Key - Can have one of CollectionOne
+export async function createForeignKey(
   schema: ExtensionSchema,
-  CollectionOne: string,
-  CollectionMany: string,
-  ForeignKey: string, // TODO: Deprecate (can be set in field1)
+  CollectionKey: string,
+  CollectionAlias: string,
   settings?: directusO2MSettings,
 ) {
-  const field1 = settings?.field1 || {};
+  const fieldKeyName = settings?.fieldKey?.field || CollectionAlias;
+  const fieldKey = settings?.fieldKey || {};
 
   schema.fields.push({
-    collection: CollectionOne,
-    field: ForeignKey,
+    collection: CollectionKey,
+    field: fieldKeyName,
     type: "integer",
     schema: {},
-    ...field1,
+    ...fieldKey,
     meta: {
       interface: "select-dropdown-m2o",
-      special: ["m2o"],
-      ...field1?.meta,
+      ...fieldKey?.meta,
     },
   });
 
-  schema.relations.push({
-    collection: CollectionOne,
-    field: ForeignKey,
-    related_collection: CollectionMany,
-    meta: { sort_field: null },
-    schema: { on_delete: "SET NULL" },
-  });
+  const relation = {
+    collection: CollectionKey,
+    field: fieldKeyName,
+    related_collection: CollectionAlias,
+    ...settings?.relation,
+    meta: {
+      sort_field: null,
+      ...settings?.relation?.meta,
+    },
+    schema: { on_delete: "SET NULL", ...settings?.relation?.schema },
+  };
+
+  if (settings?.fieldAlias) {
+    const fieldAliasName = settings?.fieldAlias?.field || CollectionKey;
+    const fieldAlias = settings?.fieldAlias || {};
+
+    schema.fields.push({
+      collection: CollectionAlias,
+      field: fieldAliasName,
+      type: "alias",
+      ...fieldAlias,
+      meta: {
+        interface: "list-o2m",
+        special: ["o2m"],
+        ...fieldAlias?.meta,
+      },
+    });
+
+    relation.meta.one_field = fieldAliasName;
+  }
+
+  schema.relations.push(relation);
 }
 
 export async function createM2ARelation(

--- a/collectivo/extensions/memberships/server/schemas/001_memberships.ts
+++ b/collectivo/extensions/memberships/server/schemas/001_memberships.ts
@@ -325,23 +325,22 @@ schema.relations = [
   },
 ];
 
-schema.flows = [
-  {
-    name: "memberships_shares_invoices",
-    icon: "receipt",
-    color: null,
-    description: null,
-    status: "active",
-    accountability: "all",
-    trigger: "event",
-    options: {
-      type: "filter",
-      scope: ["items.update", "items.create"],
-      collections: ["memberships"],
-    },
-    collectivoEndpoint: "/api/memberships/create-shares-invoice",
-  },
-];
+// schema.flows = [
+//   {
+//     name: "memberships_shares_invoices",
+//     icon: "receipt",
+//     color: null,
+//     description: null,
+//     status: "active",
+//     accountability: "all",
+//     trigger: "event",
+//     options: {
+//       type: "filter",
+//       scope: ["items.update", "items.create"],
+//       collections: ["memberships"],
+//     },
+//   },
+// ];
 
 schema.permissions = [
   {


### PR DESCRIPTION
support buttons for dashboard tiles

breaking changes:
- schema.createO2MRelation("c1", "c2", "fk") has been removed, please replace it with schema.createForeignKey("c1", "c2", {fielfKey: {field:"fk"}})
- directusCollectionSchema() has been removed, please replace it with {schema: "collection_name"} instead